### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -122,5 +122,5 @@ files:
 - docs/TESTS.md
 - pytest.ini
 - ruff.toml
-synced_at: '2026-03-17T06:12:29Z'
+synced_at: '2026-04-13T00:37:59Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-03-17T10:27:48+04:00
- Sync date: 2026-04-13T00:38:01.316463+00:00