### PR TITLE
refactor: reduce complexity & extract plotting from main.py (#222, #223)

### DIFF
--- a/src/ifunnel/financial_data_preprocessing/clean_downloaded_data.py
+++ b/src/ifunnel/financial_data_preprocessing/clean_downloaded_data.py
@@ -10,6 +10,77 @@ import os
 import pandas as pd
 
 
+def _drop_incomplete_columns(data: pd.DataFrame) -> pd.DataFrame:
+    """Drop assets that lack data at the very start or end of the period."""
+    for column in data.columns:
+        # if the first three or last three values of the column are not empty, then delete the column
+        if not data[column].values[:3].all() or not data[column].values[-3:].all():
+            data.drop(column, axis=1, inplace=True)
+    return data
+
+
+def _fill_missing_prices(data_raw: pd.DataFrame) -> pd.DataFrame:
+    """Fill each missing daily price with the closest available future price."""
+    data = data_raw.copy()
+    for asset in data_raw.columns:
+        for indx, date in enumerate(data_raw.index):
+            if data_raw.loc[date, asset]:
+                continue
+            for date_future in list(data_raw.index)[indx:]:
+                if data_raw.loc[date_future, asset]:
+                    data.loc[date, asset] = data_raw.loc[date_future, asset]
+                    print("found price")
+                    break
+    return data
+
+
+def _drop_outlier_assets(data: pd.DataFrame) -> pd.DataFrame:
+    """Drop assets whose daily return ever exceeds 20% (likely data errors)."""
+    to_delete = []
+    for asset in data.columns:
+        column = list(data[asset])
+        value_old = column[0]
+        for value in column[1:]:
+            if abs((value / value_old) - 1) > 0.20:
+                to_delete.append(asset)
+                print(asset, (value / value_old) - 1, len(to_delete))
+                break
+            value_old = value
+    for delete_col in to_delete:
+        data.drop(delete_col, axis=1, inplace=True)
+    return data
+
+
+def _select_weekly_wednesdays(data: pd.DataFrame) -> pd.DataFrame:
+    """Keep Wednesday prices, backfilling any missing Wednesday from 5 days prior."""
+    # Select only Wednesdays to be able to compute weekly returns
+    data_wed = data[pd.DatetimeIndex(data.index).weekday == 2]  # ty: ignore[unresolved-attribute]
+
+    # Check if we have all Wednesdays' prices, if not fill it with the price 5 days in the past
+    date_test = data_wed.index[0]
+    date_list = data_wed.index.to_list()
+    while date_test < date_list[-1]:
+        date_test = date_test + pd.Timedelta(days=7)
+        if date_test not in data_wed.index:
+            print(date_test)
+            data_wed.loc[date_test] = data.loc[date_test - pd.Timedelta(days=5)].to_list()
+
+    return data_wed.sort_index()
+
+
+def _to_weekly_returns(data_wed: pd.DataFrame) -> pd.DataFrame:
+    """Convert weekly Wednesday prices into percentage returns."""
+    data_wed_rets = data_wed.copy()
+    for asset in data_wed.columns:
+        data_wed_rets[asset] = data_wed[asset].pct_change()
+
+    # drop the first row, because it contains NaNs
+    data_wed_rets = data_wed_rets.drop(data_wed_rets.index[0])
+
+    wanted_columns = [col for col in data_wed_rets.columns if col[0] != "nan"]
+    return data_wed_rets[wanted_columns]
+
+
 def clean_data(data_raw: pd.DataFrame) -> pd.DataFrame | None:
     """Clean raw financial data and transform it into weekly returns.
 
@@ -30,66 +101,12 @@ def clean_data(data_raw: pd.DataFrame) -> pd.DataFrame | None:
                                the data is saved directly to a file
     """
     data_raw = data_raw.fillna("")
+    data_raw = _drop_incomplete_columns(data_raw)
+    data = _fill_missing_prices(data_raw)
+    data = _drop_outlier_assets(data)
+    data_wed = _select_weekly_wednesdays(data)
+    data_wed_rets = _to_weekly_returns(data_wed)
 
-    # Delete tickers for which we don't have data for the whole time period
-    for column in data_raw.columns:
-        # if the first three or last three values of the column are not empty, then delete the column
-        if not data_raw[column].values[:3].all() or not data_raw[column].values[-3:].all():
-            data_raw.drop(column, axis=1, inplace=True)
-
-    # Fill missing daily prices with the closest available price in the future
-    data = data_raw.copy()
-    for asset in data_raw.columns:
-        for indx, date in enumerate(data_raw.index):
-            if not data_raw.loc[date, asset]:
-                for date_future in list(data_raw.index)[indx:]:
-                    if data_raw.loc[date_future, asset]:
-                        data.loc[date, asset] = data_raw.loc[date_future, asset]
-                        print("found price")
-                        break
-                    else:
-                        continue
-
-    # Delete tickers (outliers) with daily returns bigger that 20%
-    to_delete = []
-    for asset in data.columns:
-        column = list(data[asset])
-        value_old = column[0]
-        for value in column[1:]:
-            if abs((value / value_old) - 1) > 0.20:
-                to_delete.append(asset)
-                print(asset, (value / value_old) - 1, len(to_delete))
-                break
-            else:
-                value_old = value
-    for delete_col in to_delete:
-        data.drop(delete_col, axis=1, inplace=True)
-
-    # Select only Wednesdays to be able to compute monthly returns
-    data_wed = data[pd.DatetimeIndex(data.index).weekday == 2]  # ty: ignore[unresolved-attribute]
-
-    # Check if we have all Wednesdays' prices, if not fill it with the price 5 days in the past
-    date_test = data_wed.index[0]
-    date_list = data_wed.index.to_list()
-    while date_test < date_list[-1]:
-        date_test = date_test + pd.Timedelta(days=7)
-        if date_test not in data_wed.index:
-            print(date_test)
-            data_wed.loc[date_test] = data.loc[date_test - pd.Timedelta(days=5)].to_list()
-
-    # Sort df by index
-    data_wed = data_wed.sort_index()
-
-    # Create dataframes with returns instead of prices
-    data_wed_rets = data_wed.copy()
-    for asset in data_wed.columns:
-        data_wed_rets[asset] = data_wed[asset].pct_change()
-
-    # drop the first row, because it contains NaNs
-    data_wed_rets = data_wed_rets.drop(data_wed_rets.index[0])
-
-    wanted_columns = [col for col in data_wed_rets.columns if col[0] != "nan"]
-    data_wed_rets = data_wed_rets[wanted_columns]
     # Save results with returns into data folder for the app
     data_wed_rets.to_parquet(
         os.path.join(os.path.dirname(os.getcwd()), "financial_data/all_etfs_rets.parquet.gzip"),

--- a/src/ifunnel/models/main.py
+++ b/src/ifunnel/models/main.py
@@ -7,19 +7,15 @@ The module supports backtesting, scenario analysis, and lifecycle investment mod
 """
 
 from functools import lru_cache
-from itertools import cycle
-from math import ceil
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 import plotly.io as pio
 from loguru import logger
-from plotly.subplots import make_subplots
-from scipy.stats import gaussian_kde
 
+from . import plotting
 from .clustering import cluster, pick_cluster
 from .cvar_model import cvar_model
 from .cvar_targets import get_cvar_targets
@@ -110,92 +106,13 @@ class _TradeBot:
         names: list[str],
         tickers: list[str],
     ) -> tuple[go.Figure, go.Figure]:
-        """Create performance and composition plots for backtest results.
+        """Build the backtest performance and composition figures.
 
-        This method generates two plots:
-        1. A line chart comparing the optimized portfolio performance against the benchmark
-        2. A stacked area chart showing the portfolio composition over time
-
-        Args:
-            performance: DataFrame with portfolio values over time
-            performance_benchmark: DataFrame with benchmark portfolio values over time
-            composition: DataFrame with portfolio weights for each asset over time
-            names: List of human-readable asset names
-            tickers: List of ticker symbols corresponding to the names
-
-        Returns:
-            Tuple containing:
-                - go.Figure: Line chart comparing portfolio and benchmark performance
-                - go.Figure: Stacked area chart showing portfolio composition over time
+        Thin wrapper over :func:`plotting.plot_backtest` (kept on the class so
+        the plotting logic lives in one module while the public/test call
+        surface is preserved).
         """
-        performance.index = pd.to_datetime(performance.index.values, utc=True)
-
-        # ** PERFORMANCE GRAPH **
-        try:
-            df_to_plot = pd.concat([performance, performance_benchmark], axis=1)
-        except Exception:  # noqa: BLE001  # fall back to legacy date handling on any concat failure
-            logger.warning("⚠️ Old data format.")
-            performance.index = [date.date() for date in performance.index]  # needed for old data
-            df_to_plot = pd.concat([performance, performance_benchmark], axis=1)
-
-        color_discrete_map = {
-            "Portfolio_Value": "#21304f",
-            "Benchmark_Value": "#f58f02",
-        }
-        fig = px.line(
-            df_to_plot,
-            x=df_to_plot.index,
-            y=df_to_plot.columns,
-            title="Comparison of different strategies",
-            color_discrete_map=color_discrete_map,
-        )
-        fig_performance = fig
-
-        # ** COMPOSITION GRAPH **
-        # change ISIN to NAMES in allocation df
-        composition_names = []
-        for ticker in composition.columns:
-            ticker_index = list(tickers).index(ticker)
-            composition_names.append(list(names)[ticker_index])
-        composition.columns = composition_names
-
-        composition = composition.loc[:, (composition != 0).any(axis=0)]
-        data = []
-        composition_color = (
-            px.colors.sequential.turbid
-            + px.colors.sequential.Brwnyl
-            + px.colors.sequential.YlOrBr
-            + px.colors.sequential.gray
-            + px.colors.sequential.Mint
-            + px.colors.sequential.dense
-            + px.colors.sequential.Plasma
-            + px.colors.sequential.Viridis
-            + px.colors.sequential.Cividis
-        )
-        for idx_color, isin in enumerate(composition.columns):
-            trace = go.Bar(
-                x=composition.index,
-                y=composition[isin],
-                name=str(isin),
-                marker_color=composition_color[idx_color % len(composition_color)],  # custom color
-            )
-            data.append(trace)
-
-        layout = go.Layout(barmode="stack")
-        fig = go.Figure(data=data, layout=layout)
-        fig.update_layout(
-            title="Portfolio Composition",
-            xaxis_title="Number of the Investment Period",
-            yaxis_title="Composition",
-            legend_title="Name of the Fund",
-        )
-        fig.layout.yaxis.tickformat = ",.1%"
-        fig_composition = fig
-
-        # Show figure if needed
-        # fig.show()
-
-        return fig_performance, fig_composition
+        return plotting.plot_backtest(performance, performance_benchmark, composition, names, tickers)
 
     @staticmethod
     def __plot_portfolio_densities(
@@ -204,192 +121,11 @@ class _TradeBot:
         tickers: list,
         names: list,
     ) -> tuple[go.Figure, dict[str, go.Figure], go.Figure]:
-        """METHOD TO PLOT THE LIFECYCLE SIMULATION RESULTS."""
-        # Define colors
-        colors = [
-            "#99A4AE",  # gray50
-            "#3b4956",  # dark
-            "#b7ada5",  # secondary
-            "#4099da",  # blue
-            "#8ecdc8",  # aqua
-            "#e85757",  # coral
-            "#fdd779",  # sun
-            "#644c76",  # eggplant
-            "#D8D1CA",  # warmGray50
-        ]
+        """Build the lifecycle terminal-wealth density and composition figures.
 
-        color_cycle = cycle(colors)  # To cycle through colors
-        fig = go.Figure()
-
-        max_density_across_all_datasets = 0  # Initialize max density tracker
-
-        for label, df in portfolio_performance_dict.items():
-            # Generating a range of values to evaluate the KDE
-            x_min = df["Terminal Wealth"].min()
-            x_max = df["Terminal Wealth"].max()
-            x = np.linspace(x_min, x_max, 1000)
-
-            # Kernel Density Estimation for each dataset
-            # Handle case where data has insufficient variance (singular covariance)
-            try:
-                kde = gaussian_kde(df["Terminal Wealth"])
-                density = kde(x)
-            except np.linalg.LinAlgError:
-                # Fall back to a simple histogram-based density when KDE fails
-                logger.warning(
-                    f"KDE failed for '{label}' due to insufficient variance in terminal wealth. "
-                    "Using histogram-based density estimation."
-                )
-                hist, bin_edges = np.histogram(df["Terminal Wealth"], bins=50, density=True)
-                bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
-                # Interpolate to get smooth density at x values
-                density = np.interp(x, bin_centers, hist)
-
-            # Update max density if current density peak is higher
-            max_density_across_all_datasets = max(max_density_across_all_datasets, max(density))
-
-            # Create line plot trace for this dataset
-            fig.add_trace(
-                go.Scatter(
-                    x=x,
-                    y=density,
-                    mode="lines",
-                    name=label,  # Use the dictionary key as the label
-                    line={"width": 2.5, "color": next(color_cycle)},  # Assign color from Orsted-Colors
-                )
-            )
-
-        # Add a dashed vertical line at x=0
-        fig.add_shape(
-            type="line",
-            x0=0,
-            y0=0,
-            x1=0,
-            y1=max_density_across_all_datasets,  # Use the max density across all datasets
-            line={
-                "color": "Black",
-                "width": 3,
-                "dash": "dash",  # Define dash pattern
-            },
-        )
+        Thin wrapper over :func:`plotting.plot_portfolio_densities`.
         """
-        # Update the layout
-        fig.update_layout(
-            title_text='Density function(s) of terminal wealth for risk classes in 1000 different scenarios.',
-            xaxis_title='Terminal Wealth',
-            yaxis_title='Density',
-            legend_title='Risk Class',
-            template='plotly_white'
-        )
-        """
-        # Update the layout with larger fonts
-        fig.update_layout(
-            title_text="Density function(s) of the end portfolio value for various glide paths.",
-            title_font={"size": 24},  # Increase title font size
-            xaxis_title="Target date portfolio value",
-            xaxis_title_font={"size": 18},  # Increase x-axis title font size
-            xaxis_tickfont={"size": 16},  # Increase x-axis tick label font size
-            yaxis_title="Density",
-            yaxis_title_font={"size": 18},  # Increase y-axis title font size
-            yaxis_tickfont={"size": 16},  # Increase y-axis tick label font size
-            legend_title="Risb Budget glide path",
-            legend_title_font={"size": 18},  # Increase legend title font size
-            legend_font={"size": 16},  # Increase legend text font size
-            template="plotly_white",
-        )
-
-        # Show the figure in a browser
-        # fig.show(renderer="browser")
-
-        composition_figures = {}
-        filtered_compositions = {name: comp for name, comp in compositions.items() if "reverse" not in name}
-        num_portfolios = len(filtered_compositions)
-        cols = 2 if num_portfolios > 1 else 1
-        rows = ceil(
-            num_portfolios / cols
-        )  # Calculate the number of rows needed based on the total number of compositions
-
-        subplot_titles = [f"Portfolio Composition: {name}" for name in filtered_compositions]
-        fig_subplots = make_subplots(
-            rows=rows,
-            cols=cols,
-            subplot_titles=subplot_titles,
-            vertical_spacing=0.1,
-            horizontal_spacing=0.05,
-        )
-
-        tickers_in_legend = set()
-        current_plot = 1  # Keep track of the current plot index to correctly calculate row and col
-
-        for portfolio_name, composition in filtered_compositions.items():
-            composition_names = []
-            for ticker in composition.columns[:-1]:
-                ticker_index = list(tickers).index(ticker)
-                composition_names.append(list(names)[ticker_index])
-            if "Cash" not in composition_names:
-                composition_names.append("Cash")
-            composition.columns = composition_names
-            composition = composition.loc[:, (composition != 0).any(axis=0)]
-
-            composition_color = (
-                px.colors.sequential.turbid
-                + px.colors.sequential.Brwnyl
-                + px.colors.sequential.YlOrBr
-                + px.colors.sequential.gray
-                + px.colors.sequential.Mint
-                + px.colors.sequential.dense
-                + px.colors.sequential.Plasma
-                + px.colors.sequential.Viridis
-                + px.colors.sequential.Cividis
-            )
-
-            # Create an individual figure for the current portfolio
-            individual_fig = go.Figure()
-
-            for idx_color, isin in enumerate(composition.columns):
-                show_legend = isin not in tickers_in_legend
-                tickers_in_legend.add(isin)
-
-                trace = go.Bar(
-                    x=composition.index,
-                    y=composition[isin],
-                    name=str(isin),
-                    marker_color=composition_color[idx_color % len(composition_color)],
-                    showlegend=show_legend,
-                )
-
-                # Add trace to both the subplot and the individual figure
-                row, col = divmod(current_plot - 1, cols)
-                fig_subplots.add_trace(trace, row=row + 1, col=col + 1)
-                individual_fig.add_trace(trace)
-
-            # Configure the individual figure layout
-            individual_fig.update_layout(
-                title=f"Portfolio Composition: {portfolio_name}",
-                plot_bgcolor="white",
-                barmode="stack",
-            )
-            individual_fig["layout"]["yaxis"].tickformat = ",.1%"
-
-            # Store the individual figure in the dictionary
-            composition_figures[portfolio_name] = individual_fig
-
-            current_plot += 1
-
-        fig_subplots.update_layout(
-            title="Portfolio Compositions",
-            height=500 * rows,
-            width=1000 * cols,
-            plot_bgcolor="white",
-            barmode="stack",
-        )
-        # Update y-axis tick format for all subplots
-        for i in range(1, cols * rows + 1):
-            fig_subplots["layout"][f"yaxis{i}"].tickformat = ",.1%"
-
-        # fig_subplots.show()
-
-        return fig, composition_figures, fig_subplots
+        return plotting.plot_portfolio_densities(portfolio_performance_dict, compositions, tickers, names)
 
     def get_stat(self, start_date: str, end_date: str) -> pd.DataFrame:
         """METHOD COMPUTING ANNUAL RETURNS, ANNUAL STD. DEV. & SHARPE RATIO OF ASSETS."""
@@ -491,115 +227,25 @@ class _TradeBot:
         optimal_portfolio: list | None = None,
         benchmark: list | None = None,
     ) -> go.Figure:
-        """METHOD TO PLOT THE OVERVIEW OF THE FINANCIAL PRODUCTS IN TERMS OF RISK AND RETURNS."""
-        fund_set = fund_set if fund_set else []
-        top_performers = top_performers if top_performers else []
+        """Plot the risk/return overview of the financial products.
 
-        # Get statistics for a given time period
+        Delegates figure construction to :func:`plotting.dots_figure`, passing
+        the per-asset statistics computed for the requested window.
+        """
         data = self.get_stat(start_date, end_date)
-
-        # Add data about the optimal portfolio and benchmark for plotting
-        if optimal_portfolio:
-            data.loc[optimal_portfolio[4]] = optimal_portfolio
-        if benchmark:
-            data.loc[benchmark[4]] = benchmark
-
-        # IF WE WANT TO HIGHLIGHT THE SUBSET OF ASSETS BASED ON ML
-        if ml == "MST":
-            data.loc[:, "Type"] = "Funds"
-            for fund in ml_subset:  # ty: ignore[not-iterable]
-                data.loc[fund, "Type"] = "MST subset"
-        if ml == "Clustering":
-            data.loc[:, "Type"] = ml_subset.loc[:, "Cluster"]  # ty: ignore[unresolved-attribute]
-
-        # If selected any fund for comparison
-        for fund in fund_set:
-            isin_idx = list(self.names).index(fund)
-            data.loc[self.tickers[isin_idx], "Type"] = str(data.loc[self.tickers[isin_idx], "Name"])
-            data.loc[self.tickers[isin_idx], "Size"] = 3
-
-        for fund in top_performers:
-            isin_idx = list(self.names).index(fund)
-            data.loc[self.tickers[isin_idx], "Type"] = "Top Performer"
-            data.loc[self.tickers[isin_idx], "Size"] = 3
-
-        # PLOTTING Data
-        color_discrete_map = {
-            "ETF": "#21304f",
-            "Mutual Fund": "#f58f02",
-            "Funds": "#21304f",
-            "MST subset": "#f58f02",
-            "Top Performer": "#f58f02",
-            "Cluster 1": "#21304f",
-            "Cluster 2": "#f58f02",
-            "Benchmark Portfolio": "#f58f02",
-            "Optimal Portfolio": "olive",
-        }
-        fig = px.scatter(
+        return plotting.dots_figure(
             data,
-            x="Standard Deviation of Returns",
-            y="Average Annual Returns",
-            color="Type",
-            size="Size",
-            size_max=8,
-            hover_name="Name",
-            hover_data={"Sharpe Ratio": True, "ISIN": True, "Size": False},
-            color_discrete_map=color_discrete_map,
-            title="Annual Returns and Standard Deviation of Returns from " + start_date[:10] + " to " + end_date[:10],
+            start_date,
+            end_date,
+            ml=ml,
+            ml_subset=ml_subset,
+            fund_set=fund_set,
+            top_performers=top_performers,
+            optimal_portfolio=optimal_portfolio,
+            benchmark=benchmark,
+            names=self.names,
+            tickers=self.tickers,
         )
-
-        # AXIS IN PERCENTAGES
-        fig.layout.yaxis.tickformat = ",.1%"
-        fig.layout.xaxis.tickformat = ",.1%"
-
-        # RISK LEVEL MARKER
-        min_risk = data["Standard Deviation of Returns"].min()
-        max_risk = data["Standard Deviation of Returns"].max()
-        risk_level = {
-            "Risk Class 1": 0.005,
-            "Risk Class 2": 0.02,
-            "Risk Class 3": 0.05,
-            "Risk Class 4": 0.10,
-            "Risk Class 5": 0.15,
-            "Risk Class 6": 0.25,
-            "Risk Class 7": max_risk,
-        }
-        # Initialize dynamic risk levels
-        actual_risk_level = set()
-        for i in range(1, 8):
-            k = "Risk Class " + str(i)
-            if (risk_level[k] >= min_risk) and (risk_level[k] <= max_risk):
-                actual_risk_level.add(i)
-
-        if max(actual_risk_level) < 7:  # pragma: no cover (dead code - 7 always in set)
-            actual_risk_level.add(max(actual_risk_level) + 1)  # Add the final risk level
-
-        for level in actual_risk_level:
-            k = "Risk Class " + str(level)
-            fig.add_vline(
-                x=risk_level[k], line_width=1, line_dash="dash", line_color="#7c90a0"
-            )  # annotation_text=k, annotation_position="top left")
-            fig.add_annotation(
-                x=risk_level[k] - 0.01,
-                y=max(data["Average Annual Returns"]),
-                text=k,
-                textangle=-90,
-                showarrow=False,
-            )
-
-        # RETURN LEVEL MARKER
-        fig.add_hline(y=0, line_width=1.5, line_color="rgba(233, 30, 99, 0.5)")
-
-        # TITLES
-        fig.update_annotations(font_color="#000000")
-        fig.update_layout(
-            xaxis_title="Annualised standard deviation of returns (Risk)",
-            yaxis_title="Annualised average returns",
-        )
-        # Position of legend
-        fig.update_layout(legend={"yanchor": "bottom", "y": 0.01, "xanchor": "left", "x": 0.01})
-        # fig.show()
-        return fig
 
     def mst(self, start_date: str, end_date: str, n_mst_runs: int, plot: bool = False) -> tuple:
         """METHOD TO RUN MST METHOD AND PRINT RESULTS."""

--- a/src/ifunnel/models/plotting.py
+++ b/src/ifunnel/models/plotting.py
@@ -1,0 +1,390 @@
+"""Plotly figure builders for the trading bot.
+
+These pure functions were extracted from ``main._TradeBot`` so that the bot's
+orchestration logic (backtests, lifecycle analysis, asset selection) stays
+separate from the rendering code. Each function only constructs and returns
+Plotly figures; none mutate bot state.
+"""
+
+from itertools import cycle
+from math import ceil
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from loguru import logger
+from plotly.subplots import make_subplots
+from scipy.stats import gaussian_kde
+
+# Categorical colour ramp reused for composition bar charts.
+_COMPOSITION_COLORS = (
+    px.colors.sequential.turbid
+    + px.colors.sequential.Brwnyl
+    + px.colors.sequential.YlOrBr
+    + px.colors.sequential.gray
+    + px.colors.sequential.Mint
+    + px.colors.sequential.dense
+    + px.colors.sequential.Plasma
+    + px.colors.sequential.Viridis
+    + px.colors.sequential.Cividis
+)
+
+
+def plot_backtest(
+    performance: pd.DataFrame,
+    performance_benchmark: pd.DataFrame,
+    composition: pd.DataFrame,
+    names: list[str],
+    tickers: list[str],
+) -> tuple[go.Figure, go.Figure]:
+    """Create performance and composition plots for backtest results.
+
+    Args:
+        performance: DataFrame with portfolio values over time.
+        performance_benchmark: DataFrame with benchmark values over time.
+        composition: DataFrame with portfolio weights per asset over time.
+        names: Human-readable asset names.
+        tickers: Ticker symbols corresponding to ``names``.
+
+    Returns:
+        Tuple of (performance line chart, composition stacked-bar chart).
+    """
+    performance.index = pd.to_datetime(performance.index.values, utc=True)
+
+    # ** PERFORMANCE GRAPH **
+    try:
+        df_to_plot = pd.concat([performance, performance_benchmark], axis=1)
+    except Exception:  # noqa: BLE001  # fall back to legacy date handling on any concat failure
+        logger.warning("⚠️ Old data format.")
+        performance.index = [date.date() for date in performance.index]  # needed for old data
+        df_to_plot = pd.concat([performance, performance_benchmark], axis=1)
+
+    fig_performance = px.line(
+        df_to_plot,
+        x=df_to_plot.index,
+        y=df_to_plot.columns,
+        title="Comparison of different strategies",
+        color_discrete_map={"Portfolio_Value": "#21304f", "Benchmark_Value": "#f58f02"},
+    )
+
+    # ** COMPOSITION GRAPH ** — change ISIN to NAMES in allocation df
+    composition_names = []
+    for ticker in composition.columns:
+        ticker_index = list(tickers).index(ticker)
+        composition_names.append(list(names)[ticker_index])
+    composition.columns = composition_names
+    composition = composition.loc[:, (composition != 0).any(axis=0)]
+
+    data = []
+    for idx_color, isin in enumerate(composition.columns):
+        data.append(
+            go.Bar(
+                x=composition.index,
+                y=composition[isin],
+                name=str(isin),
+                marker_color=_COMPOSITION_COLORS[idx_color % len(_COMPOSITION_COLORS)],
+            )
+        )
+
+    fig_composition = go.Figure(data=data, layout=go.Layout(barmode="stack"))
+    fig_composition.update_layout(
+        title="Portfolio Composition",
+        xaxis_title="Number of the Investment Period",
+        yaxis_title="Composition",
+        legend_title="Name of the Fund",
+    )
+    fig_composition.layout.yaxis.tickformat = ",.1%"
+
+    return fig_performance, fig_composition
+
+
+def _density_figure(portfolio_performance_dict: dict) -> go.Figure:
+    """Build the terminal-wealth density (KDE) figure across glide paths."""
+    colors = [
+        "#99A4AE",  # gray50
+        "#3b4956",  # dark
+        "#b7ada5",  # secondary
+        "#4099da",  # blue
+        "#8ecdc8",  # aqua
+        "#e85757",  # coral
+        "#fdd779",  # sun
+        "#644c76",  # eggplant
+        "#D8D1CA",  # warmGray50
+    ]
+    color_cycle = cycle(colors)  # To cycle through colors
+    fig = go.Figure()
+    max_density_across_all_datasets = 0  # Initialize max density tracker
+
+    for label, df in portfolio_performance_dict.items():
+        # Generate a range of values to evaluate the KDE
+        x = np.linspace(df["Terminal Wealth"].min(), df["Terminal Wealth"].max(), 1000)
+
+        # KDE per dataset; handle insufficient variance (singular covariance)
+        try:
+            density = gaussian_kde(df["Terminal Wealth"])(x)
+        except np.linalg.LinAlgError:
+            logger.warning(
+                f"KDE failed for '{label}' due to insufficient variance in terminal wealth. "
+                "Using histogram-based density estimation."
+            )
+            hist, bin_edges = np.histogram(df["Terminal Wealth"], bins=50, density=True)
+            bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+            density = np.interp(x, bin_centers, hist)
+
+        max_density_across_all_datasets = max(max_density_across_all_datasets, max(density))
+        fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=density,
+                mode="lines",
+                name=label,
+                line={"width": 2.5, "color": next(color_cycle)},
+            )
+        )
+
+    # Dashed vertical line at x=0
+    fig.add_shape(
+        type="line",
+        x0=0,
+        y0=0,
+        x1=0,
+        y1=max_density_across_all_datasets,
+        line={"color": "Black", "width": 3, "dash": "dash"},
+    )
+    fig.update_layout(
+        title_text="Density function(s) of the end portfolio value for various glide paths.",
+        title_font={"size": 24},
+        xaxis_title="Target date portfolio value",
+        xaxis_title_font={"size": 18},
+        xaxis_tickfont={"size": 16},
+        yaxis_title="Density",
+        yaxis_title_font={"size": 18},
+        yaxis_tickfont={"size": 16},
+        legend_title="Risb Budget glide path",
+        legend_title_font={"size": 18},
+        legend_font={"size": 16},
+        template="plotly_white",
+    )
+    return fig
+
+
+def _composition_subplots(
+    filtered_compositions: dict[str, pd.DataFrame],
+    tickers: list,
+    names: list,
+) -> tuple[dict[str, go.Figure], go.Figure]:
+    """Build per-portfolio composition figures plus a combined subplot grid."""
+    num_portfolios = len(filtered_compositions)
+    cols = 2 if num_portfolios > 1 else 1
+    rows = ceil(num_portfolios / cols)  # rows needed for all compositions
+
+    fig_subplots = make_subplots(
+        rows=rows,
+        cols=cols,
+        subplot_titles=[f"Portfolio Composition: {name}" for name in filtered_compositions],
+        vertical_spacing=0.1,
+        horizontal_spacing=0.05,
+    )
+
+    composition_figures: dict[str, go.Figure] = {}
+    tickers_in_legend: set = set()
+    current_plot = 1  # current plot index, to compute row and col
+
+    for portfolio_name, composition in filtered_compositions.items():
+        composition_names = []
+        for ticker in composition.columns[:-1]:
+            ticker_index = list(tickers).index(ticker)
+            composition_names.append(list(names)[ticker_index])
+        if "Cash" not in composition_names:
+            composition_names.append("Cash")
+        composition.columns = composition_names
+        composition = composition.loc[:, (composition != 0).any(axis=0)]
+
+        individual_fig = go.Figure()
+        for idx_color, isin in enumerate(composition.columns):
+            show_legend = isin not in tickers_in_legend
+            tickers_in_legend.add(isin)
+            trace = go.Bar(
+                x=composition.index,
+                y=composition[isin],
+                name=str(isin),
+                marker_color=_COMPOSITION_COLORS[idx_color % len(_COMPOSITION_COLORS)],
+                showlegend=show_legend,
+            )
+            row, col = divmod(current_plot - 1, cols)
+            fig_subplots.add_trace(trace, row=row + 1, col=col + 1)
+            individual_fig.add_trace(trace)
+
+        individual_fig.update_layout(
+            title=f"Portfolio Composition: {portfolio_name}",
+            plot_bgcolor="white",
+            barmode="stack",
+        )
+        individual_fig["layout"]["yaxis"].tickformat = ",.1%"
+        composition_figures[portfolio_name] = individual_fig
+        current_plot += 1
+
+    fig_subplots.update_layout(
+        title="Portfolio Compositions",
+        height=500 * rows,
+        width=1000 * cols,
+        plot_bgcolor="white",
+        barmode="stack",
+    )
+    for i in range(1, cols * rows + 1):
+        fig_subplots["layout"][f"yaxis{i}"].tickformat = ",.1%"
+
+    return composition_figures, fig_subplots
+
+
+def plot_portfolio_densities(
+    portfolio_performance_dict: dict,
+    compositions: dict[str, pd.DataFrame],
+    tickers: list,
+    names: list,
+) -> tuple[go.Figure, dict[str, go.Figure], go.Figure]:
+    """Plot lifecycle simulation results: terminal-wealth densities and compositions.
+
+    Returns:
+        Tuple of (density figure, per-portfolio composition figures, combined subplots).
+    """
+    fig = _density_figure(portfolio_performance_dict)
+    filtered_compositions = {name: comp for name, comp in compositions.items() if "reverse" not in name}
+    composition_figures, fig_subplots = _composition_subplots(filtered_compositions, tickers, names)
+    return fig, composition_figures, fig_subplots
+
+
+def _annotate_dots_data(
+    data: pd.DataFrame,
+    ml: str,
+    ml_subset: list | pd.DataFrame | None,
+    fund_set: list,
+    top_performers: list,
+    optimal_portfolio: list | None,
+    benchmark: list | None,
+    names: list,
+    tickers: list,
+) -> pd.DataFrame:
+    """Annotate the stats frame with portfolio/benchmark/ML/fund highlights."""
+    if optimal_portfolio:
+        data.loc[optimal_portfolio[4]] = optimal_portfolio
+    if benchmark:
+        data.loc[benchmark[4]] = benchmark
+
+    # Highlight the subset of assets selected by an ML method
+    if ml == "MST":
+        data.loc[:, "Type"] = "Funds"
+        for fund in ml_subset:  # ty: ignore[not-iterable]
+            data.loc[fund, "Type"] = "MST subset"
+    if ml == "Clustering":
+        data.loc[:, "Type"] = ml_subset.loc[:, "Cluster"]  # ty: ignore[unresolved-attribute]
+
+    for fund in fund_set:
+        isin_idx = list(names).index(fund)
+        data.loc[tickers[isin_idx], "Type"] = str(data.loc[tickers[isin_idx], "Name"])
+        data.loc[tickers[isin_idx], "Size"] = 3
+
+    for fund in top_performers:
+        isin_idx = list(names).index(fund)
+        data.loc[tickers[isin_idx], "Type"] = "Top Performer"
+        data.loc[tickers[isin_idx], "Size"] = 3
+
+    return data
+
+
+def _add_risk_level_markers(fig: go.Figure, data: pd.DataFrame) -> None:
+    """Add dashed vertical risk-class boundaries and their annotations."""
+    min_risk = data["Standard Deviation of Returns"].min()
+    max_risk = data["Standard Deviation of Returns"].max()
+    risk_level = {
+        "Risk Class 1": 0.005,
+        "Risk Class 2": 0.02,
+        "Risk Class 3": 0.05,
+        "Risk Class 4": 0.10,
+        "Risk Class 5": 0.15,
+        "Risk Class 6": 0.25,
+        "Risk Class 7": max_risk,
+    }
+    actual_risk_level = set()
+    for i in range(1, 8):
+        k = "Risk Class " + str(i)
+        if (risk_level[k] >= min_risk) and (risk_level[k] <= max_risk):
+            actual_risk_level.add(i)
+
+    if max(actual_risk_level) < 7:  # pragma: no cover (dead code - 7 always in set)
+        actual_risk_level.add(max(actual_risk_level) + 1)  # Add the final risk level
+
+    for level in actual_risk_level:
+        k = "Risk Class " + str(level)
+        fig.add_vline(x=risk_level[k], line_width=1, line_dash="dash", line_color="#7c90a0")
+        fig.add_annotation(
+            x=risk_level[k] - 0.01,
+            y=max(data["Average Annual Returns"]),
+            text=k,
+            textangle=-90,
+            showarrow=False,
+        )
+
+
+def dots_figure(
+    data: pd.DataFrame,
+    start_date: str,
+    end_date: str,
+    *,
+    ml: str = "",
+    ml_subset: list | pd.DataFrame | None = None,
+    fund_set: list | None = None,
+    top_performers: list | None = None,
+    optimal_portfolio: list | None = None,
+    benchmark: list | None = None,
+    names: list,
+    tickers: list,
+) -> go.Figure:
+    """Build the risk/return scatter of all products with risk-class markers."""
+    fund_set = fund_set if fund_set else []
+    top_performers = top_performers if top_performers else []
+
+    data = _annotate_dots_data(
+        data, ml, ml_subset, fund_set, top_performers, optimal_portfolio, benchmark, names, tickers
+    )
+
+    fig = px.scatter(
+        data,
+        x="Standard Deviation of Returns",
+        y="Average Annual Returns",
+        color="Type",
+        size="Size",
+        size_max=8,
+        hover_name="Name",
+        hover_data={"Sharpe Ratio": True, "ISIN": True, "Size": False},
+        color_discrete_map={
+            "ETF": "#21304f",
+            "Mutual Fund": "#f58f02",
+            "Funds": "#21304f",
+            "MST subset": "#f58f02",
+            "Top Performer": "#f58f02",
+            "Cluster 1": "#21304f",
+            "Cluster 2": "#f58f02",
+            "Benchmark Portfolio": "#f58f02",
+            "Optimal Portfolio": "olive",
+        },
+        title="Annual Returns and Standard Deviation of Returns from " + start_date[:10] + " to " + end_date[:10],
+    )
+
+    # Axes in percentages
+    fig.layout.yaxis.tickformat = ",.1%"
+    fig.layout.xaxis.tickformat = ",.1%"
+
+    _add_risk_level_markers(fig, data)
+
+    # Return-level marker
+    fig.add_hline(y=0, line_width=1.5, line_color="rgba(233, 30, 99, 0.5)")
+
+    fig.update_annotations(font_color="#000000")
+    fig.update_layout(
+        xaxis_title="Annualised standard deviation of returns (Risk)",
+        yaxis_title="Annualised average returns",
+    )
+    fig.update_layout(legend={"yanchor": "bottom", "y": 0.01, "xanchor": "left", "x": 0.01})
+    return fig


### PR DESCRIPTION
## Summary
Follow-up quality refactor after the rhiza v1.1.1 bump (PR #216), addressing two scorecard findings.

### #222 — reduce C-ranked cyclomatic complexity
`radon cc src` now reports **no block ranking C or worse** (previously three):
- `clean_downloaded_data.clean_data`: **CC 18 → 1**, split into staged helpers (`_drop_incomplete_columns`, `_fill_missing_prices`, `_drop_outlier_assets`, `_select_weekly_wednesdays`, `_to_weekly_returns`).
- `main._TradeBot.plot_dots` (CC 15) and `__plot_portfolio_densities` (CC 12): decomposed into focused helpers, all now ≤ B.

### #223 — decompose the `main.py` god-module
- Extracted **all** Plotly figure construction from `_TradeBot` into a new `src/ifunnel/models/plotting.py`.
- `_TradeBot` keeps thin delegating methods, so the public API and all test call sites (including the mangled-name references) are unchanged.
- **`main.py`: 961 → 607 lines (−37%)**, cleanly separating rendering from orchestration.
- Note: the remaining bulk of `main.py` is genuine orchestration (`backtest`, `lifecycle_scenario_analysis`) that belongs on the bot, so it sits above the ~400-LOC heuristic by design. Closes #222; partially addresses #223 (plotting separated).

## Verification (local, against current `main` deps incl. plotly 6.9)
- `make fmt` ✅
- `make typecheck` ✅ (ty + mypy --strict)
- `make test` ✅ — **131 passed, 2 skipped, coverage 99.90%** (behavior preserved)
- `uvx radon cc src` ✅ — no C-or-worse block

Closes #222
