### PR TITLE
chore: own SECURITY.md and drop its false fuzzing claim

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -4,6 +4,7 @@ host: github
 ref: v1.4.2
 include: []
 exclude:
+- SECURITY.md
 - .github/workflows/rhiza_mutation.yml
 - .github/workflows/rhiza_fuzzing.yml
 - .github/CONFIG.md
@@ -40,7 +41,6 @@ files:
 - .rhiza/CONTRIBUTING.md
 - .rhiza/semgrep.yml
 - LICENSE
-- SECURITY.md
 - cliff.toml
 - docs/assets/rhiza-logo.svg
 - docs/development/DEVCONTAINER.md

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -11,6 +11,10 @@ templates:
 # Paths matched against the *destination* (where the file lands here), not the
 # clone-relative bundle path — `normalise_excludes` only tidies separators.
 exclude:
+    # SECURITY.md makes factual claims about THIS repo's security posture (which scanners,
+    # which release protections). Only the repo knows which are true -- the template shipped a
+    # fuzzing claim that was false here -- so the file is owned here, not template-managed.
+    - SECURITY.md
     # Opt-in gates this repo has never opted into: `gh variable list` is empty, so
     # neither MUTATION_ENABLED nor FUZZING_ENABLED is set. mutation's gate is in the
     # caller so it never starts; fuzzing's is inside the reusable workflow, so it ran

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,6 @@ This project implements several security measures:
 - **CodeQL**: Automated code scanning for Python and GitHub Actions
 - **Bandit**: Python security linter integrated in CI and pre-commit
 - **Secret Scanning**: GitHub secret scanning enabled on this repository
-- **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets on pull requests and scheduled batch runs
 
 ### Supply Chain Security
 - **SLSA Provenance**: Build attestations for release artifacts (public repositories only)


### PR DESCRIPTION
## What

- Remove the `- **Fuzzing**: ClusterFuzzLite exercises Atheris-based fuzz targets ...` bullet from `SECURITY.md`.
- Add `SECURITY.md` to `exclude:` in `.rhiza/template.yml` (and mirror it in `template.lock`), making the file repo-owned.

## Why

The fuzzing claim was false. This repo has no `.clusterfuzzlite/` config and no `rhiza_fuzzing.yml` caller, so nothing fuzzes anything. A security policy that overstates the posture is worse than one that stays quiet.

Excluding the file follows from that. `SECURITY.md` ships in the template's `legal` bundle, but its **Security Measures** section is a set of factual claims about *this* repo — which scanners run, which release protections exist — and only the repo knows which hold. The template cannot, as the fuzzing line demonstrates.

Upstream applies the same standard to itself: `jebel-quant/rhiza` carries `tests/security/test_security_md_claims.py`, which parses each claim and demands evidence for it. That test ships in no bundle, so the responsibility lands here.

## Notes

The file stays on disk — this is an ownership change, not a removal. Empirically the template applies deltas rather than overwriting this file (a bespoke `SECURITY.md` elsewhere survived syncs from v1.2.0 through v1.4.2 untouched), so the exclusion is belt-and-braces that makes the intent explicit instead of relying on merge behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)