### PR TITLE
chore: update rhiza to v1.5.2

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.2
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.2
     secrets: inherit

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.5.2
     secrets: inherit
     # `contents: read` only. The `write` scope this stub used to grant existed solely for
     # the retired branch push; compiling and uploading an artifact need no write access.

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.2
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         groups: ["lint", "fast"]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: 0.26
+    rev: "0.26"
     hooks:
       - id: validate-pyproject
         groups: ["python", "fast"]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: de568b1e79e5871c58b4349762ce9dfd31d73e99
+sha: bb365b643155b80d93bbd9c20fb9e55f42f1fb33
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.1
+ref: v1.5.2
 include: []
 exclude:
 - SECURITY.md
@@ -52,5 +52,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-23T12:41:17Z'
+synced_at: '2026-08-24T04:41:40Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.1"
+ref: "v1.5.2"
 
 profiles:
     - github-project

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.1.0
+RHIZA_TASK ?= rhiza-task@1.3.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.


### PR DESCRIPTION
Template `jebel-quant/rhiza`: **v1.5.1 → v1.5.2**.

- Sync exit code **0** — clean merge, no conflicts, so nothing had to be resolved by taking upstream.
- **11 template-owned files** committed (10 managed files + `.rhiza/template.lock`), plus the `.rhiza/template.yml` ref bump:
  - `.github/workflows/rhiza_benchmark.yml`
  - `.github/workflows/rhiza_book.yml`
  - `.github/workflows/rhiza_ci.yml`
  - `.github/workflows/rhiza_codeql.yml`
  - `.github/workflows/rhiza_marimo.yml`
  - `.github/workflows/rhiza_paper.yml`
  - `.github/workflows/rhiza_scorecard.yml`
  - `.github/workflows/rhiza_weekly.yml`
  - `.pre-commit-config.yaml`
  - `Makefile`
- Nothing was left unstaged in the working tree — the stager reported no leftovers and the tree is clean.

**No gates were run** — `/update` only syncs. Run `/rhiza:quality` for a scorecard, `/rhiza:status` to see what is now synced.
